### PR TITLE
fix(udm-listener): Don't emit a duplicate privileged key in securityContext

### DIFF
--- a/helm/udm-listener/templates/statefulset.yaml
+++ b/helm/udm-listener/templates/statefulset.yaml
@@ -65,7 +65,7 @@ spec:
           command: [ "wait-for-nats.py" ]
           {{- if .Values.containerSecurityContext.enabled }}
           securityContext:
-            {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+            {{- omit .Values.containerSecurityContext "enabled" "privileged" | toYaml | nindent 12 }}
             privileged: false  # Explicitly set privileged to false
           {{- end }}
           image: "{{ coalesce .Values.waitForDependency.image.registry .Values.global.imageRegistry }}/{{ .Values.waitForDependency.image.repository }}:{{ .Values.waitForDependency.image.tag }}"
@@ -91,7 +91,7 @@ spec:
         - name: "main"
           {{- if .Values.containerSecurityContext.enabled }}
           securityContext:
-            {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+            {{- omit .Values.containerSecurityContext "enabled" "privileged" | toYaml | nindent 12 }}
             privileged: false  # Explicitly set privileged to false
           {{- end }}
           image: "{{ coalesce .Values.image.registry .Values.global.imageRegistry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
The container securityContext blocks render the containerSecurityContext
values map via toYaml and then append a literal `privileged: false` line.
When a consumer's values legitimately include `privileged` in that map —
openDesk does since v1.16.0 (d392be49 - https://gitlab.opencode.de/bmi/opendesk/deployment/opendesk/-/commit/d392be49b6ad4a7e041cf0f86aebc84a5b2aefa5), which sets `privileged: false` in every
nubus containerSecurityContext block of its helmfile — the rendered
manifest contains the key twice.

Helm's own YAML handling tolerates duplicate keys, but strict parsers
reject the manifest — Flux CD's kustomize build fails with
`mapping key "privileged" already defined`, breaking GitOps consumers of
the chart.

Omit `privileged` from the toYaml map so the appended literal remains the
single, authoritative occurrence — the hardening intent (privileged is
always false) is unchanged.

Assisted-by: Claude Fable 5